### PR TITLE
ID values on context

### DIFF
--- a/lib/bizness/context.rb
+++ b/lib/bizness/context.rb
@@ -6,4 +6,13 @@ class Bizness::Context < OpenStruct
   def successful?
     error.nil?
   end
+
+  # If a value responds to #id, automatically set an equivalent "_id" key/value pair. For example, if an instance
+  # of an ActiveRecord class Widget is set on a context object of :widget, set another attribute called :widget_id with
+  # the value of the object's ID. This helps ensure the context's values can be sent as a message across application
+  # boundries.
+  def to_h
+    super.each { |k, v| send("#{k}_id=", v.id) if v.respond_to?(:id) && send("#{k}_id").nil? }
+    super
+  end
 end

--- a/lib/bizness/operation.rb
+++ b/lib/bizness/operation.rb
@@ -6,7 +6,7 @@ class Bizness::Operation
   attr_reader :context
 
   def initialize(context = {})
-    @context = context.is_a?(Bizness::Context) ? context : Bizness::Context.new(context)
+    @context = Bizness::Context.new(context.to_h)
   end
 
   def self.filters

--- a/spec/context_spec.rb
+++ b/spec/context_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+describe Bizness::Context do
+  subject { Bizness::Context.new }
+
+  describe "#succesful?" do
+    context "when error is empty" do
+      it "returns true" do
+        subject.error = nil
+        expect(subject).to be_successful
+      end
+    end
+
+    context "when error is set" do
+      it "returns false" do
+        subject.error = "Oops"
+        expect(subject).to_not be_successful
+      end
+    end
+  end
+
+  describe "#to_h" do
+    it "includes id attributes for object's that respond to #id" do
+      subject.widget = Widget.create
+      expect(subject.to_h[:widget]).to eq(subject.widget)
+      expect(subject.to_h[:widget_id]).to eq(subject.widget.id)
+    end
+  end
+end


### PR DESCRIPTION
Business operations generally work with ActiveRecord models. However, if you’ve wired up the events filter to broadcast the operations as they execute, passing objects in your message payload won’t work (unless you want to be bound to always using the ActiveSupport notifications adapter).

This PR adds the ability for the `#to_h` to automatically add `*_id` methods for any values that respond to `#id`, making the message more usable for event subscribers. For example, if you’ve set a Widget AR object on your context as `widget`, the `to_h` method now automatically adds `widget_id` and its value to the resulting hash.

This means you can still pass AR objects into your operations, yet still take advantage of the automatic event broadcasting knowing that the subscriber at the other end can easily know how to find the record out of the database on the other end.

Note: This works for any object that responds to `#id`, not just AR objects.