### PR TITLE
Allow operations to override their filter chain.

### DIFF
--- a/lib/bizness/operation.rb
+++ b/lib/bizness/operation.rb
@@ -1,6 +1,20 @@
 module Bizness::Operation
   attr_reader :error
 
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    def filters(*filter_overrides)
+      @filter_overrides = filter_overrides.flatten.compact
+    end
+
+    def filter_overrides
+      @filter_overrides
+    end
+  end
+
   def call!
     run
     successful?
@@ -28,8 +42,12 @@ module Bizness::Operation
 
   private
 
+  def filter_overrides
+    Array(self.class.filter_overrides).flatten.compact.empty? ? Bizness.filters : self.class.filter_overrides
+  end
+
   def run
-    Bizness.run(self)
+    Bizness.run(self, filters: filter_overrides)
   rescue => e
     self.error = e.message
   end


### PR DESCRIPTION
This grants more control to operations to control the filters that are executed in the pipeline.