### PR TITLE
Policies

### DIFF
--- a/bizness.gemspec
+++ b/bizness.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activerecord"
+  spec.add_dependency "i18n"
   spec.add_dependency "hey-pubsub", "~> 0.2.0"
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/bizness.rb
+++ b/lib/bizness.rb
@@ -2,6 +2,7 @@ require "bizness/version"
 require "active_record"
 require "forwardable"
 require "hey"
+require "i18n"
 
 module Bizness
   def self.configure
@@ -24,6 +25,7 @@ end
 
 require "bizness/configuration"
 require "bizness/operation"
+require "bizness/policy"
 require "bizness/subscriber"
 require "bizness/filters/base_filter"
 require "bizness/filters/active_record_transaction_filter"

--- a/lib/bizness/policy.rb
+++ b/lib/bizness/policy.rb
@@ -1,0 +1,76 @@
+# Adds convenience methods for defining a policy object and recording its violations. To take use this module, do the
+# following:
+#
+# 1. Write one or more private predicate methods that define your policies requirements
+# 2. Define violation messages in your corresponding I18n locale YAML files
+#
+# -- string_format_policy.rb
+#
+# class StringFormatPolicy
+#   include Bizness::Policy
+#
+#   def initialize(string)
+#     @string = string
+#   end
+#
+#   private
+#
+#   attr_reader :string
+#
+#   def all_caps?
+#    string.upcase == string
+#   end
+# end
+#
+# -- en.yml
+#
+# en:
+#   policies:
+#     string_format_policy:
+#       violations:
+#         all_caps: "Must be an uppercase string"
+#
+# Example usage:
+#
+# policy = StringFormatPolicy.new("abcd")
+# policy.successful?
+# => false
+#
+# policy.violations
+# => ["Must be an uppercase string"]
+#
+module Bizness::Policy
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  def violations
+    @violations || []
+  end
+
+  def successful?
+    self.violations = []
+    self.class.__requirements__.each do |m|
+      self.violations << self.class.violation_message(m) unless send(m)
+    end
+    violations.empty?
+  end
+
+  module ClassMethods
+    def violation_message(method)
+      policy = self.name.gsub(/(.)([A-Z])/,'\1_\2').downcase
+      message_key = "policies.#{policy}.violations.#{method.to_s.delete("?")}"
+      I18n.t(message_key)
+    end
+
+    def __requirements__
+      @__requirements__ ||= begin
+        private_instance_methods(false).select { |m| m.to_s[/\?$/] }
+      end
+    end
+  end
+
+  private
+
+  attr_writer :violations
+end

--- a/spec/policy_spec.rb
+++ b/spec/policy_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+describe Bizness::Policy do
+  let(:string) { "Bar!" }
+
+  subject { MockPolicy.new(foo: string) }
+
+  describe "#successful?" do
+    context "when all predicates pass" do
+      let(:string) { "BAR" }
+
+      it "is successful?" do
+        expect(subject).to be_successful
+      end
+
+      it "has no violations" do
+        expect(subject.violations).to be_empty
+      end
+    end
+
+    context "when a predicate fails" do
+      it "adds a violation messages" do
+        subject.successful?
+        expect(subject.violations).to match_array(["String must be alphanumeric", "Characters must be all uppercase"])
+      end
+
+      it "is not successful" do
+        expect(subject).to_not be_successful
+      end
+    end
+  end
+
+  describe "#__requirements__" do
+    it "returns a list of predicate methods" do
+      expect(MockPolicy.__requirements__).to match_array([:alphanumeric?, :all_caps?])
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'bizness'
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f }
+I18n.config.available_locales = :en
+I18n.load_path = Dir[File.dirname(__FILE__) + "/support/**/*.yml"]
+I18n.backend.load_translations

--- a/spec/support/en.yml
+++ b/spec/support/en.yml
@@ -1,0 +1,6 @@
+en:
+  policies:
+    mock_policy:
+      violations:
+        all_caps: "Characters must be all uppercase"
+        alphanumeric: "String must be alphanumeric"

--- a/spec/support/mock_policy.rb
+++ b/spec/support/mock_policy.rb
@@ -1,0 +1,19 @@
+class MockPolicy
+  include Bizness::Policy
+
+  attr_reader :foo
+
+  def initialize(foo:)
+    @foo = foo
+  end
+
+  private
+
+  def alphanumeric?
+    foo.match(/^[[:alpha:]]+$/)
+  end
+
+  def all_caps?
+    foo == foo.upcase
+  end
+end


### PR DESCRIPTION
When writing operations, it’s often a good idea to vet the object performing, or being performed on, with a series of policy assumptions. Generally these assumptions are represented in a Policy object. If a policy fails, you should raise an error with the list of violations. 

This PR adds a convenience module to make simple to write standardized policy objects.

By including this module, the class receives `successful?` method that executes all private predicate methods and collects a list of violations for those that fail. The violation messages are found in locale files as configured using the I18n gem.