### PR TITLE
Always propagate operation return value from default filters

### DIFF
--- a/lib/bizness/filters/event_filter.rb
+++ b/lib/bizness/filters/event_filter.rb
@@ -11,6 +11,7 @@ module Bizness::Filters
     def evented_call
       result = filtered_operation.call
       Hey.publish!("#{event_name}#{delimiter}#{successful? ? "succeeded" : "failed"}", payload(result))
+      result
     rescue Exception => e
       Hey.publish!("#{event_name}#{delimiter}aborted", payload.merge(error: e.message, stacktrace: e.backtrace, exception: e.class.name))
       raise e

--- a/spec/filters/active_record_transaction_filter_spec.rb
+++ b/spec/filters/active_record_transaction_filter_spec.rb
@@ -1,20 +1,29 @@
 require "spec_helper"
 
 describe Bizness::Filters::ActiveRecordTransactionFilter do
-  it "commits the transaction" do
-    op = MockOperation.new(foo: "bar")
-    allow(op).to receive(:call) { Widget.new.save! }
-    filter = Bizness::Filters::ActiveRecordTransactionFilter.new(op)
-    filter.call
-    expect(Widget.count).to eq(1)
+  let(:op) { op = MockOperation.new(foo: "bar") }
+
+  context "when successful" do
+    subject(:filter) {  Bizness::Filters::ActiveRecordTransactionFilter.new(op) }
+    before do
+      allow(op).to receive(:call) { Widget.new.save!; "RETURN VALUE" }
+    end
+
+    it "commits the transaction" do
+      filter.call
+      expect(Widget.count).to eq(1)
+    end
+
+    it "propagates the return value" do
+      expect(filter.call).to eq("RETURN VALUE")
+    end
   end
 
   context "when failed" do
-    it "rolls back the transaction" do
-      op = MockOperation.new(foo: "bar")
+    it "rolls back the transaction and propagates the exception" do
       allow(op).to receive(:call).and_raise("Oops")
       filter = Bizness::Filters::ActiveRecordTransactionFilter.new(op)
-      begin; filter.call; rescue; end
+      expect{ filter.call }.to raise_error(/Oops/)
       expect(Widget.all).to be_empty
     end
   end

--- a/spec/filters/event_filter_spec.rb
+++ b/spec/filters/event_filter_spec.rb
@@ -1,40 +1,52 @@
 require "spec_helper"
 
 describe Bizness::Filters::EventFilter do
+  let(:op) { op = MockOperation.new(foo: "bar") }
+  subject(:filter) { Bizness::Filters::EventFilter.new(op) }
+
   it "publishes an executed event" do
-    op = MockOperation.new(foo: "bar")
-    filter = Bizness::Filters::EventFilter.new(op)
     expect(Hey).to receive(:publish!).with("mock_operation:executed", {foo: "bar"})
     filter.call
   end
 
   context "when succeeded" do
-    it "publishes a succeeded event" do
-      op = MockOperation.new(foo: "bar")
+    before do
       allow(op).to receive(:successful?).and_return(true)
-      filter = Bizness::Filters::EventFilter.new(op)
+    end
+
+    it "publishes a succeeded event" do
       expect(Hey).to receive(:publish!).once.with("mock_operation:executed", {foo: "bar"}).and_call_original
       expect(Hey).to receive(:publish!).once.with("mock_operation:succeeded", {foo: "bar", custom_message: "Operation completed"})
       filter.call
     end
+
+    it "propagates the return value of the operation" do
+      expect(filter.call).to eq("MOCK RETURN VALUE")
+    end
   end
 
   context "when failed" do
-    it "publishes a failed event" do
-      op = MockOperation.new(foo: "bar")
+    before do
       allow(op).to receive(:successful?).and_return(false)
-      filter = Bizness::Filters::EventFilter.new(op)
+    end
+
+    it "publishes a failed event" do
       expect(Hey).to receive(:publish!).once.with("mock_operation:executed", {foo: "bar"}).and_call_original
       expect(Hey).to receive(:publish!).once.with("mock_operation:failed", hash_including({foo: "bar"}))
       filter.call
     end
+
+    it "propagates the return value of the operation" do
+      expect(filter.call).to eq("MOCK RETURN VALUE")
+    end
   end
 
   context "when aborted" do
-    it "publishes a aborted event" do
-      op = MockOperation.new(foo: "bar")
+    before do
       allow(op).to receive(:call).and_raise("Oops")
-      filter = Bizness::Filters::EventFilter.new(op)
+    end
+
+    it "publishes a aborted event" do
       expect(Hey).to receive(:publish!).once.with("mock_operation:executed", {foo: "bar"}).and_call_original
       expect(Hey).to receive(:publish!).once.with("mock_operation:aborted", hash_including(foo: "bar", error: "Oops"))
       expect { filter.call }.to raise_error("Oops")

--- a/spec/support/mock_operation.rb
+++ b/spec/support/mock_operation.rb
@@ -10,6 +10,7 @@ class MockOperation
 
   def call
     self.custom_message = "Operation completed"
+    "MOCK RETURN VALUE"
   end
 
   def to_h


### PR DESCRIPTION
The EventFilter was always returning `nil` from calls to `Bizness.run`.

Now we make sure the operation's return value is returned.

Updated the specs to make this explicit.

> Note, we do not make any guarantee that other custom filters preserve the return value.